### PR TITLE
Fix missing env.example template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ celerybeat.pid
 # Environments
 .env
 .env.*
+!.env.example.j2
 env/
 venv/
 

--- a/openapi_to_mcp/templates/.env.example.j2
+++ b/openapi_to_mcp/templates/.env.example.j2
@@ -1,0 +1,7 @@
+# Environment configuration for {{ server_name }}
+# Replace with the base URL of the target API.
+# Example: TARGET_API_BASE_URL={{ api_base_url_comment }}
+TARGET_API_BASE_URL=YOUR_API_BASE_URL_HERE
+
+# Optional authorization header in the format 'Header-Name: Value'
+#TARGET_API_AUTH_HEADER=Authorization: Bearer YOUR_TOKEN


### PR DESCRIPTION
## Summary
- provide `.env.example.j2` template so the generator works
- allow `.env.example.j2` to be committed via `.gitignore`

## Testing
- `pytest -q`
