### PR TITLE
Update error response test

### DIFF
--- a/tests/unit/test_server_tester.py
+++ b/tests/unit/test_server_tester.py
@@ -216,9 +216,10 @@ def test_format_response_with_error() -> None:
     req_id = 123
 
     result = _format_response(response_data, req_id)
+    expected = {
+        "error": {"code": 100, "message": "Test error"},
+        "jsonrpc": "2.0",
+        "id": req_id,
+    }
 
-    assert "error" in result
-    assert result["error"]["code"] == 100
-    assert result["error"]["message"] == "Test error"
-    assert result["jsonrpc"] == "2.0"
-    assert result["id"] == req_id
+    assert result == expected


### PR DESCRIPTION
## Summary
- ensure `_format_response` error return includes `jsonrpc` and request id

## Testing
- `pytest -q tests/unit/test_server_tester.py::test_format_response_with_error`
- `pytest -q`
