### PR TITLE
Add changelog and README quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-06-13
+### Added
+- Command-line tool to generate Node.js/TypeScript MCP servers from OpenAPI v3 specifications.
+- Automatic mapping of OpenAPI operations to MCP tools with JSON Schema generation.
+- Creation of a runnable server project using `@modelcontextprotocol/sdk`.
+- Support for `stdio` and `sse` transports with configurable port for `sse`.
+- Example `.env` handling and basic error mapping in the generated server.
+- Integrated linting (ruff) and formatting (black).
+- Unit and integration tests using `pytest`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,26 @@ The generated server acts as a proxy, receiving MCP tool calls and translating t
 *   Unit and integration tests (`pytest`).
 *   JSON logging.
 
+## Quickstart
+
+1. Install dependencies:
+```bash
+poetry install --no-dev
+```
+(Use `poetry install` for development.)
+
+2. Generate a server from your OpenAPI spec:
+```bash
+poetry run openapi-to-mcp generate 
+  --openapi-json <path_or_url> 
+  --output-dir ./mcp-server
+```
+
+3. Follow the instructions in the generated `README.md` in `./mcp-server` to build and run the server.
+
+See [docs/USAGE_EXAMPLES.md](docs/USAGE_EXAMPLES.md) for detailed examples.
+
+
 ## 🚀 Installation / Setup
 
 **Prerequisites:**
@@ -345,6 +365,7 @@ Ensure you have installed dependencies using `poetry install --with dev` (or `po
 
 ## 📄 License
 This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for details.
+See [CHANGELOG.md](CHANGELOG.md) for release notes.
 
 ## 📚 References
 * [OpenAPI Specification](https://swagger.io/specification/)


### PR DESCRIPTION
## Summary
- document version 0.1.0 in a new CHANGELOG
- add a short Quickstart guide in README
- link to usage examples and the changelog

## Testing
- `poetry run poe check`
