### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2026-03-22
+
+### Added
+
+- Added opt-in retry-budget and circuit-breaker controls for safe generated tools, including generated runtime config, per-tool policy overrides, and structured runtime error metadata.
+- Added reviewable performance presets for generated runtimes, with transparent expansions for concurrency, queueing, timeout, caching, rate limiting, retries, and circuit breakers.
+- Added generated-server end-to-end coverage for resilience controls, invalid preset startup failures, and preset precedence behavior.
+
+### Changed
+
+- Hardened resilience behavior so non-retryable upstream failures no longer reset accumulated circuit-breaker state.
+- Clarified runtime docs and generated project docs around preset precedence, blank preset-backed env placeholders, and conservative preset cache-cap behavior.
+- Hardened performance preset parsing so only declared preset names are accepted at startup.
+
 ## [0.8.0] - 2026-03-22
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openapi-to-mcp"
-version = "0.8.0"
+version = "0.9.0"
 description = "Generate, run, and test Node.js/TypeScript MCP servers from OpenAPI specifications."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -622,7 +622,7 @@ wheels = [
 
 [[package]]
 name = "openapi-to-mcp"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Prepare the `0.9.0` release.

This release captures the runtime resilience and performance preset work that landed after `0.8.0`:

- retry-budget controls
- circuit-breaker controls
- reviewable performance presets

## What changed

- bumped package version to `0.9.0`
- updated `uv.lock` for the new editable package version
- added the `0.9.0` changelog entry

## Included in 0.9.0

- opt-in retry-budget controls for safe generated tools
- opt-in circuit-breaker controls for safe generated tools
- structured runtime error metadata for retry-budget exhaustion and breaker-open cases
- reviewable performance presets for generated runtimes:
  - `conservative`
  - `balanced`
  - `aggressive`
- explicit override precedence over preset-expanded defaults
- generated-server end-to-end coverage for:
  - resilience controls
  - invalid preset startup failures
  - preset precedence behavior

## Why

`0.8.0` shipped access-control and audit/redaction controls.

Since then, the generated runtime has gained a complete resilience layer plus a preset layer on top of the lower-level controls. That is a clean minor-release boundary.

## Notes

- no code changes in this PR beyond release metadata
- merging this PR to `master` should trigger the existing automated GitHub Release workflow
