### PR TITLE
Add PyPI publishing and package-build validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
       - name: Run Python test suite
         run: uv run pytest
 
+      - name: Build Python distribution
+        run: uv build
+
   e2e-generated-server:
     name: e2e-generated-server (node-${{ matrix.node-version }})
     needs: quality-py314

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -135,6 +136,11 @@ jobs:
             echo "Tag ${TAG_NAME} already exists on a different commit: ${existing_ref}" >&2
             exit 1
           fi
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
       - name: Create or update GitHub Release
         env:

--- a/README.md
+++ b/README.md
@@ -17,16 +17,30 @@ Standalone CLI for diagnosing, diffing, generating, running, and testing Node.js
 
 ## Install
 
-Treat `openapi-to-mcp` as an installable CLI first.
+New releases are published to PyPI.
+
+Run it without a permanent install:
 
 ```bash
-uv tool install git+https://github.com/nihal1294/openapi-to-mcp@vX.Y.Z
+uvx openapi-to-mcp --help
+```
+
+Install it permanently:
+
+```bash
+uv tool install openapi-to-mcp
+# or
+pip install openapi-to-mcp
 openapi-to-mcp --help
 ```
 
-Until the project is published to PyPI, this is the cleanest end-user install path.
+If you need a fallback before a given release reaches PyPI, install from a tagged Git release instead:
 
-GitHub Releases also publish a wheel and source tarball for each version. Those artifacts are useful for pinned manual installs and packaging verification, but the docs treat them as an advanced path rather than the default user experience.
+```bash
+uv tool install git+https://github.com/nihal1294/openapi-to-mcp@vX.Y.Z
+```
+
+GitHub Releases also publish a wheel and source tarball for each version. Those artifacts remain useful for pinned manual installs and packaging verification, but the default user path for new releases is PyPI.
 
 ## Quickstart
 
@@ -81,7 +95,7 @@ Public product documentation lives on GitHub Pages:
 - generated runtime controls for concurrency, queueing, timeout, bounded caching, rate limiting, retries, and circuit breakers
 - generated-server E2E coverage against a local mock API
 - CLI E2E coverage for `generate`, `run`, and `test-server`
-- version-aware GitHub Releases automation on `master`
+- version-aware GitHub Releases and PyPI publishing automation on `master`
 
 ## Development
 

--- a/docs/guides/local-workflows.md
+++ b/docs/guides/local-workflows.md
@@ -142,6 +142,12 @@ Release behavior:
 
 - releases are automated from `master`
 - a release runs when the version changes or the matching version tag is missing
-- the release workflow builds the wheel and sdist, ensures the version tag exists, and creates or updates the GitHub Release
+- the release workflow builds the wheel and sdist, publishes them to PyPI, ensures
+  the version tag exists, and creates or updates the GitHub Release
+
+One-time PyPI setup outside the repo:
+
+- configure a trusted publisher for `nihal1294/openapi-to-mcp`
+- point it at `.github/workflows/release.yml` on the default branch
 
 Code scanning is expected through GitHub default CodeQL setup, not a workflow in the repo.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,9 +2,28 @@
 
 Treat `openapi-to-mcp` as a standalone CLI first.
 
-## Preferred install path today
+## Install from PyPI
 
-Because the project is not yet published to PyPI, the cleanest end-user path today is a tagged Git install with `uv tool install`.
+New releases are published to PyPI.
+
+Run the CLI without a permanent install:
+
+```bash
+uvx openapi-to-mcp --help
+```
+
+Install it permanently:
+
+```bash
+uv tool install openapi-to-mcp
+# or
+pip install openapi-to-mcp
+openapi-to-mcp --help
+```
+
+## Tagged Git fallback
+
+If a specific release is not yet available on PyPI, use a tagged Git install instead:
 
 ```bash
 uv tool install git+https://github.com/nihal1294/openapi-to-mcp@vX.Y.Z
@@ -24,17 +43,18 @@ Then verify:
 openapi-to-mcp --help
 ```
 
-## Why this is the preferred user path
+## Why the PyPI path is preferred
 
-- it installs the CLI as an isolated tool,
-- it avoids mixing project and development dependencies into your shell,
-- it keeps the public docs aligned with the installable CLI experience.
+- it keeps installation on the standard Python packaging path,
+- it works with both `uv` and `pip`,
+- it keeps source-checkout workflows separate from end-user installs.
 
 ## GitHub Release artifacts
 
 Each GitHub Release also publishes a wheel and source tarball.
 
-Treat those artifacts as the canonical release outputs for packaging and pinned manual installs. The public docs still prefer `uv tool install` from a tagged release because it is the simplest end-user flow until PyPI publishing exists.
+Treat those artifacts as the canonical build outputs for packaging verification and
+pinned manual installs. They are no longer the default user path.
 
 ## Source checkout and development install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,17 @@ description = "Generate, run, and test Node.js/TypeScript MCP servers from OpenA
 readme = "README.md"
 requires-python = ">=3.14"
 authors = [{ name = "Nihal Rao", email = "nihaliddya@gmail.com" }]
+license = { file = "LICENSE" }
+keywords = ["openapi", "mcp", "model-context-protocol", "typescript", "codegen", "server", "cli", "python", "openapi-to-mcp"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Code Generators",
+    "Topic :: Utilities",
+]
 dependencies = [
     "click==8.3.1",
     "requests==2.32.5",
@@ -16,6 +27,13 @@ dependencies = [
     "rich-click==1.9.7",
     "structlog==25.5.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/nihal1294/openapi-to-mcp"
+Documentation = "https://nihal1294.github.io/openapi-to-mcp/"
+Repository = "https://github.com/nihal1294/openapi-to-mcp"
+Issues = "https://github.com/nihal1294/openapi-to-mcp/issues"
+Changelog = "https://github.com/nihal1294/openapi-to-mcp/blob/master/CHANGELOG.md"
 
 [project.scripts]
 openapi-to-mcp = "openapi_to_mcp.cli:cli"


### PR DESCRIPTION
## Summary

This PR makes the project ready for PyPI-backed releases.

It adds trusted publishing to the release workflow, validates package builds in CI, improves package metadata, and updates install docs to treat PyPI as the default user path.

## What changed

### Release workflow
Updated the release workflow to publish built distributions to PyPI using trusted publishing.

This keeps the existing release behavior intact:

- detect version bumps or missing tags
- run tests
- build wheel and sdist
- upload release artifacts
- ensure the version tag exists
- create or update the GitHub Release

and adds:

- publish distributions to PyPI

### CI validation
Added a package-build step to CI so packaging regressions fail before release.

### Package metadata
Expanded `pyproject.toml` metadata with:

- license
- keywords
- classifiers
- project URLs

### Install docs
Updated public install guidance to be PyPI-first while keeping a tagged-Git fallback for releases that are not yet available on PyPI.

Also documented the one-time PyPI trusted-publisher setup required outside the repo.

## Why

The project now has release automation and build artifacts, but installation still depends on tagged Git URLs and the release workflow stops short of PyPI publishing.

This PR removes that adoption barrier without changing runtime behavior.

## Validation

Ran locally:

```bash
uv build
NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict
.venv/bin/python - <<'PY'
from pathlib import Path
import yaml

for path in [Path('.github/workflows/ci.yml'), Path('.github/workflows/release.yml')]:
    with path.open('r', encoding='utf-8') as fh:
        yaml.safe_load(fh)

print("workflow yaml ok")
PY
```

Results:

- wheel and sdist built successfully
- docs build passed
- workflow YAML parse check passed

## Notes

- No version bump in this PR
- No generated-server E2E changes are required
- One external prerequisite remains: configure the PyPI trusted publisher for this repository and workflow
